### PR TITLE
feat(responses): add BMC analytics computation and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Kiro spec workspace — local agent state, not for the team repo
+.kiro/
+
+# Postman collections kept locally; team workflows live elsewhere
+postman/

--- a/api/src/responses/bmc-analytics.spec.ts
+++ b/api/src/responses/bmc-analytics.spec.ts
@@ -1,0 +1,151 @@
+import { computeBmcAnalytics } from './bmc-analytics';
+
+describe('computeBmcAnalytics', () => {
+  it('matches the Cost Structure fixture from the spreadsheet (3.50 / 35%)', () => {
+    const data = {
+      q1: 'No',
+      q1_impact: 9,
+      q2: 'No',
+      q2_impact: 9,
+      q3: 'Yes',
+      q3_impact: 8,
+      q4: 'Yes',
+      q4_impact: 9,
+      q5: 'Yes',
+      q5_impact: 9,
+      q6: 'Yes',
+      q6_impact: 9,
+      q7: 'Yes',
+      q7_impact: 9,
+      q8: 'No',
+      q8_impact: 7,
+      q9: 'Yes',
+      q9_impact: 7,
+      q10: 'Yes',
+      q10_impact: 9,
+    };
+
+    expect(computeBmcAnalytics(data)).toEqual({
+      score: 3.5,
+      percentage: 35,
+      total: 10,
+      answered: 10,
+      questions: 10,
+    });
+  });
+
+  // Each block was cross-checked against the "BMC Analytics" tab.
+  it.each([
+    {
+      name: 'Revenue Streams',
+      impacts: [10, 10, 8, 7, 9, 9, 9],
+      answers: ['Yes', 'Yes', 'Yes', 'Yes', 'Yes', 'Yes', 'Yes'],
+      score: 8.86,
+      percentage: 89,
+    },
+    {
+      name: 'Value Proposition',
+      impacts: [10, 10, 10, 8],
+      answers: ['Yes', 'Yes', 'Yes', 'Yes'],
+      score: 9.5,
+      percentage: 95,
+    },
+    {
+      name: 'Key Resources',
+      impacts: [10, 10, 10, 10],
+      answers: ['No', 'No', 'No', 'Yes'],
+      score: -5,
+      percentage: -50,
+    },
+    {
+      name: 'Channels',
+      impacts: [1, 1, 1, 1, 10],
+      answers: ['No', 'No', 'No', 'No', 'No'],
+      score: -2.8,
+      percentage: -28,
+    },
+  ])(
+    'matches the $name block ($score / $percentage%)',
+    ({ impacts, answers, score, percentage }) => {
+      const data: Record<string, unknown> = {};
+      impacts.forEach((impact, i) => {
+        data[`q${i + 1}`] = answers[i];
+        data[`q${i + 1}_impact`] = impact;
+      });
+
+      const result = computeBmcAnalytics(data);
+      expect(result.score).toBe(score);
+      expect(result.percentage).toBe(percentage);
+    },
+  );
+
+  it('excludes unanswered questions from the average', () => {
+    const data = {
+      q1: 'Yes',
+      q1_impact: 8,
+      q2: 'No',
+      q2_impact: 4,
+      // q3 has no answer/impact at all
+      q3: null,
+      q3_impact: null,
+    };
+
+    // Only q1 (+8) and q2 (-4) count → mean = 2 over 2 answered.
+    expect(computeBmcAnalytics(data)).toEqual({
+      score: 2,
+      percentage: 20,
+      total: 10,
+      answered: 2,
+      questions: 3,
+    });
+  });
+
+  it('treats an answer without an impact as unanswered', () => {
+    const data = { q1: 'Yes', q2: 'No', q2_impact: 6 };
+    const result = computeBmcAnalytics(data);
+    expect(result.answered).toBe(1);
+    expect(result.questions).toBe(2);
+    expect(result.score).toBe(-6);
+    expect(result.percentage).toBe(-60);
+  });
+
+  it('returns zeros when nothing is answered (placeholder data)', () => {
+    const data = { q1: 'Answer to question 1', q2: 'Answer to question 2' };
+    expect(computeBmcAnalytics(data)).toEqual({
+      score: 0,
+      percentage: 0,
+      total: 10,
+      answered: 0,
+      questions: 2,
+    });
+  });
+
+  it('returns zeros for an empty object', () => {
+    expect(computeBmcAnalytics({})).toEqual({
+      score: 0,
+      percentage: 0,
+      total: 10,
+      answered: 0,
+      questions: 0,
+    });
+  });
+
+  it('ignores non-question keys and reason fields', () => {
+    const data = {
+      q1: 'Yes',
+      q1_impact: 10,
+      q1_reason: 'because',
+      company: 'abc',
+      notes: 'irrelevant',
+    };
+    const result = computeBmcAnalytics(data);
+    expect(result.questions).toBe(1);
+    expect(result.answered).toBe(1);
+    expect(result.score).toBe(10);
+  });
+
+  it('tolerates numeric impacts encoded as strings', () => {
+    const data = { q1: 'Yes', q1_impact: '8' };
+    expect(computeBmcAnalytics(data).score).toBe(8);
+  });
+});

--- a/api/src/responses/bmc-analytics.ts
+++ b/api/src/responses/bmc-analytics.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure computation of BMC (Business Model Canvas) diagnostic analytics for a
+ * single Response, mirroring the "BMC Analytics" tab of the source
+ * spreadsheet.
+ *
+ * A BMC diagnostic form is flat, with three keys per question:
+ *   - `qN`         : the answer, `"Yes"` or `"No"`
+ *   - `qN_impact`  : the impact weight, a number from 1 to 10
+ *   - `qN_reason`  : free-text notes (does not affect the score)
+ *
+ * The spreadsheet derives a hidden "signed impact" per question:
+ *   signedImpact = (answer === "Yes" ? +1 : -1) * impact
+ *
+ * and then, per block (one form = one block):
+ *   score      = mean(signedImpact) over ANSWERED questions only
+ *   percentage = round(score * 10)        // score is on a -10..10 scale
+ *   total      = 10                        // the maximum impact
+ *
+ * A question is only counted when it has both a valid `Yes`/`No` answer and a
+ * finite numeric impact; blank rows are excluded from the average exactly as
+ * the spreadsheet excludes empty cells.
+ */
+
+export interface BmcAnalytics {
+  /** Mean signed impact over answered questions, rounded to 2 decimals. */
+  score: number;
+  /** `score * 10` rounded to the nearest whole percent (the headline number). */
+  percentage: number;
+  /** Maximum attainable score — always 10. */
+  total: number;
+  /** Number of questions that contributed to the score. */
+  answered: number;
+  /** Number of `qN` questions discovered in the data. */
+  questions: number;
+}
+
+/** Matches a question-answer key such as `q1`, `q12` (not `q1_impact`). */
+const QUESTION_KEY_REGEX = /^q(\d+)$/;
+
+function isYesNo(value: unknown): value is 'Yes' | 'No' {
+  return value === 'Yes' || value === 'No';
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  // RJSF normally emits numbers, but tolerate numeric strings just in case.
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Compute BMC analytics from a parsed Response `data` object.
+ *
+ * The input is the JSON already parsed from `Response.data`. Unknown,
+ * non-`qN`, and `qN_reason` keys are ignored. When no question is answered,
+ * `score` and `percentage` are `0`.
+ */
+export function computeBmcAnalytics(
+  data: Record<string, unknown>,
+): BmcAnalytics {
+  let questions = 0;
+  let answered = 0;
+  let sum = 0;
+
+  for (const key of Object.keys(data)) {
+    const match = QUESTION_KEY_REGEX.exec(key);
+    if (!match) {
+      continue;
+    }
+    questions += 1;
+
+    const answer = data[key];
+    const impact = toFiniteNumber(data[`q${match[1]}_impact`]);
+    if (!isYesNo(answer) || impact === null) {
+      continue;
+    }
+
+    answered += 1;
+    sum += (answer === 'Yes' ? 1 : -1) * impact;
+  }
+
+  const score = answered > 0 ? sum / answered : 0;
+
+  return {
+    score: round2(score),
+    percentage: Math.round(score * 10),
+    total: 10,
+    answered,
+    questions,
+  };
+}

--- a/api/src/responses/responses.controller.spec.ts
+++ b/api/src/responses/responses.controller.spec.ts
@@ -80,6 +80,20 @@ describe('ResponsesController', () => {
     expect(result).toEqual({ deletedCount: 1 });
   });
 
+  it('returns BMC analytics for a response', async () => {
+    const analytics = {
+      score: 3.5,
+      percentage: 35,
+      total: 10,
+      answered: 10,
+      questions: 10,
+    };
+    jest.spyOn(service, 'getAnalytics').mockResolvedValue(analytics);
+    const result = await controller.analytics('1');
+    expect(result).toEqual(analytics);
+    expect(service.getAnalytics as jest.Mock).toHaveBeenCalledWith('1');
+  });
+
   it('declares AuthGuard before AccessGuard at the controller level', () => {
     const guards = Reflect.getMetadata(
       GUARDS_METADATA,

--- a/api/src/responses/responses.controller.ts
+++ b/api/src/responses/responses.controller.ts
@@ -82,6 +82,21 @@ export class ResponsesController {
     return this.responsesService.findOne({ _id: id });
   }
 
+  @Get(':id/analytics')
+  @ApiOperation({ summary: 'Get BMC diagnostic analytics for a response' })
+  @ApiOkResponse({
+    description:
+      'Per-block BMC analytics: score (mean signed impact), percentage, and totals.',
+  })
+  @ApiNotFoundResponse({
+    description: 'The response with the given id was not found.',
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized.' })
+  @ApiForbiddenResponse({ description: 'Forbidden.' })
+  async analytics(@Param('id') id: string) {
+    return this.responsesService.getAnalytics(id);
+  }
+
   @Patch(':id')
   @ApiOperation({ summary: 'Update a response' })
   @ApiOkResponse({

--- a/api/src/responses/responses.service.spec.ts
+++ b/api/src/responses/responses.service.spec.ts
@@ -1,8 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ResponsesService } from './responses.service';
 import { getModelToken } from '@nestjs/mongoose';
 import { Response } from './schemas/response.schema';
 import { mockModel } from '../common/mocks/model';
+
+const VALID_ID = 'a'.repeat(24);
 
 describe('ResponsesService', () => {
   let service: ResponsesService;
@@ -69,5 +72,51 @@ describe('ResponsesService', () => {
     const result = await service.deleteOne({ _id: '1' });
     expect(result).toEqual({ deletedCount: 1 });
     expect(mockModel.deleteOne).toHaveBeenCalledWith({ _id: '1' });
+  });
+
+  describe('getAnalytics', () => {
+    it('computes BMC analytics from a response', async () => {
+      mockModel.findOne.mockReturnThis();
+      mockModel.exec.mockResolvedValue({
+        data: JSON.stringify({
+          q1: 'Yes',
+          q1_impact: 8,
+          q2: 'No',
+          q2_impact: 4,
+        }),
+      });
+
+      const result = await service.getAnalytics(VALID_ID);
+
+      expect(result).toEqual({
+        score: 2,
+        percentage: 20,
+        total: 10,
+        answered: 2,
+        questions: 2,
+      });
+    });
+
+    it('throws 404 for a malformed id without touching the model', async () => {
+      await expect(service.getAnalytics('not-an-id')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('throws 404 when the response is not found', async () => {
+      mockModel.findOne.mockReturnThis();
+      mockModel.exec.mockResolvedValue(null);
+      await expect(service.getAnalytics(VALID_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('throws 404 when stored data is not valid JSON', async () => {
+      mockModel.findOne.mockReturnThis();
+      mockModel.exec.mockResolvedValue({ data: 'not json{' });
+      await expect(service.getAnalytics(VALID_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/api/src/responses/responses.service.ts
+++ b/api/src/responses/responses.service.ts
@@ -1,7 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, AnyKeys, QueryFilter, UpdateQuery } from 'mongoose';
 import { Response } from './schemas/response.schema';
+import { BmcAnalytics, computeBmcAnalytics } from './bmc-analytics';
+
+// 24-char hex string — the canonical Mongo ObjectId wire format. A malformed
+// id short-circuits to a 404 instead of triggering a Mongoose CastError 500.
+const OBJECT_ID_HEX_REGEX = /^[0-9a-fA-F]{24}$/;
 
 @Injectable()
 export class ResponsesService {
@@ -31,5 +36,41 @@ export class ResponsesService {
 
   deleteOne(filter: QueryFilter<Response>) {
     return this.responseModel.deleteOne(filter);
+  }
+
+  /**
+   * Compute BMC diagnostic analytics for a single Response.
+   *
+   * Loads the Response by id, parses its stringified `data` payload, and runs
+   * the per-block score/percentage computation (see {@link computeBmcAnalytics}).
+   * A malformed id, a missing Response, or unparseable `data` all surface as a
+   * 404 so the route never leaks a 500 on bad input.
+   */
+  async getAnalytics(id: string): Promise<BmcAnalytics> {
+    if (!OBJECT_ID_HEX_REGEX.test(id)) {
+      throw new NotFoundException('Response not found.');
+    }
+
+    const response = await this.responseModel.findOne({ _id: id }).exec();
+    if (!response) {
+      throw new NotFoundException('Response not found.');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(response.data);
+    } catch {
+      throw new NotFoundException('Response data is not valid JSON.');
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new NotFoundException('Response data is not a valid object.');
+    }
+
+    return computeBmcAnalytics(parsed as Record<string, unknown>);
   }
 }

--- a/api/src/users/users.controller.spec.ts
+++ b/api/src/users/users.controller.spec.ts
@@ -261,7 +261,7 @@ describe('UsersController (backward-compatibility regression for /users)', () =>
 
     // Object.keys won't expose unset properties, so round-trip the fields
     // through a fresh instance to confirm every expected key is settable.
-    const probe = new CreateUserDto() as Record<string, unknown>;
+    const probe = new CreateUserDto() as unknown as Record<string, unknown>;
     for (const field of expected) {
       probe[field] = field === 'access' ? 'READ' : `value-${field}`;
     }
@@ -380,7 +380,7 @@ describe('UsersController (backward-compatibility regression for /users)', () =>
 
   it('preserves User response schema field names', () => {
     // Pin the externally-visible field set on the User class.
-    const probe = new User() as Record<string, unknown>;
+    const probe = new User() as unknown as Record<string, unknown>;
     probe.company = '60f1b9b3b3b3b3b3b3b3b3b3';
     probe.email = 'a@b.com';
     probe.name = 'A';


### PR DESCRIPTION
- Add computeBmcAnalytics function to calculate Business Model Canvas diagnostic scores with comprehensive test coverage
- Implement BmcAnalytics interface with score, percentage, total, answered, and questions metrics
- Add bmc-analytics.spec.ts with 10 test cases covering edge cases, unanswered questions, and data validation
- Update responses controller and service to integrate BMC analytics functionality
- Update responses controller and service tests to reflect new analytics behavior
