### PR TITLE
feat(cohorts,companies,programs): enrich cohort details and expand co…

### DIFF
--- a/api/src/cohorts/cohorts.controller.spec.ts
+++ b/api/src/cohorts/cohorts.controller.spec.ts
@@ -50,13 +50,14 @@ describe('CohortsController', () => {
     expect(result).toEqual(5);
   });
 
-  it('should find one cohort', async () => {
-    const cohort = { name: 'Cohort 1' };
+  it('should find one cohort with stats', async () => {
+    const cohort = { id: '1', name: 'Cohort 1', companiesCount: 4 };
     jest
-      .spyOn(service, 'findOne' as keyof CohortsService)
+      .spyOn(service, 'findOneWithStats' as keyof CohortsService)
       .mockResolvedValue(cohort as any);
     const result = await controller.findOne('1');
     expect(result).toEqual(cohort);
+    expect(service.findOneWithStats as jest.Mock).toHaveBeenCalledWith('1');
   });
 
   it('should update a cohort', async () => {

--- a/api/src/cohorts/cohorts.controller.ts
+++ b/api/src/cohorts/cohorts.controller.ts
@@ -78,7 +78,7 @@ export class CohortsController {
   })
   @ApiUnauthorizedResponse({ description: 'Unauthorized.' })
   findOne(@Param('id') id: string) {
-    return this.cohortsService.findOne({ _id: id });
+    return this.cohortsService.findOneWithStats(id);
   }
 
   @UseGuards(AuthGuard)

--- a/api/src/cohorts/cohorts.service.spec.ts
+++ b/api/src/cohorts/cohorts.service.spec.ts
@@ -72,6 +72,33 @@ describe('CohortsService', () => {
     );
   });
 
+  describe('findOneWithStats', () => {
+    it('enriches the cohort with its affiliated companies count', async () => {
+      cohortModelMock.findOne.mockResolvedValue({
+        name: 'Cohort 1',
+        toJSON: () => ({ id: 'cid1', name: 'Cohort 1' }),
+      });
+      companyModelMock.countDocuments.mockResolvedValue(4);
+
+      const result = await service.findOneWithStats('cid1');
+
+      expect(result).toEqual({
+        id: 'cid1',
+        name: 'Cohort 1',
+        companiesCount: 4,
+      });
+      expect(companyModelMock.countDocuments).toHaveBeenCalledWith({
+        cohort: 'cid1',
+      });
+    });
+
+    it('returns null when the cohort does not exist', async () => {
+      cohortModelMock.findOne.mockResolvedValue(null);
+      const result = await service.findOneWithStats('missing');
+      expect(result).toBeNull();
+    });
+  });
+
   describe('deleteOne', () => {
     it('should delete cohort if no companies exist', async () => {
       const cohort = { _id: 'cid1', name: 'Cohort 1' };

--- a/api/src/cohorts/cohorts.service.ts
+++ b/api/src/cohorts/cohorts.service.ts
@@ -27,6 +27,32 @@ export class CohortsService {
     return this.cohortModel.findOne(filter);
   }
 
+  /**
+   * Fetch a single cohort by id, enriched with the number of companies
+   * affiliated with it (`companiesCount`). Returns `null` when not found so
+   * the controller mirrors the existing not-found behaviour. Used by
+   * `GET /cohorts/:id`; the list endpoints are intentionally left unchanged.
+   */
+  async findOneWithStats(id: string) {
+    const cohort = await this.cohortModel.findOne({ _id: id });
+    if (!cohort) {
+      return null;
+    }
+
+    const companiesCount = await this.companyModel.countDocuments({
+      cohort: id as any,
+    });
+
+    // Serialise via the model's toJSON (normalize plugin → `id`, no `_id`)
+    // when available; tests pass plain objects, so fall back to the object.
+    const base =
+      typeof (cohort as { toJSON?: () => unknown }).toJSON === 'function'
+        ? (cohort as { toJSON: () => Record<string, unknown> }).toJSON()
+        : (cohort as unknown as Record<string, unknown>);
+
+    return { ...base, companiesCount };
+  }
+
   updateOne(filter: QueryFilter<Cohort>, update: UpdateQuery<Cohort>) {
     return this.cohortModel.updateOne(filter, update);
   }

--- a/api/src/companies/dto/create-company.dto.ts
+++ b/api/src/companies/dto/create-company.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsMongoId, IsNotEmpty } from 'class-validator';
+import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateCompanyDto {
   @IsMongoId()
@@ -22,11 +22,47 @@ export class CreateCompanyDto {
   })
   mainPointOfContact: string;
 
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'Email of the main point of contact.',
+    example: 'john.doe@acme.com',
+    required: false,
+  })
+  mainPocEmail?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'Phone number of the main point of contact.',
+    example: '+233241234567',
+    required: false,
+  })
+  mainPocPhone?: string;
+
   @ApiProperty({
     description: 'The alternative point of contact for the company.',
     example: 'Jane Doe',
   })
   altPointOfContact: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'Email of the alternative point of contact.',
+    example: 'jane.doe@acme.com',
+    required: false,
+  })
+  altPocEmail?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'Phone number of the alternative point of contact.',
+    example: '+233247654321',
+    required: false,
+  })
+  altPocPhone?: string;
 
   @ApiProperty({
     description: 'The project manager for the company.',

--- a/api/src/companies/schemas/company.schema.ts
+++ b/api/src/companies/schemas/company.schema.ts
@@ -26,9 +26,25 @@ export class Company {
   @Prop()
   mainPointOfContact: string;
 
+  @ApiProperty({ example: 'john.doe@acme.com', required: false })
+  @Prop()
+  mainPocEmail: string;
+
+  @ApiProperty({ example: '+233241234567', required: false })
+  @Prop()
+  mainPocPhone: string;
+
   @ApiProperty({ example: 'Jane Doe' })
   @Prop()
   altPointOfContact: string;
+
+  @ApiProperty({ example: 'jane.doe@acme.com', required: false })
+  @Prop()
+  altPocEmail: string;
+
+  @ApiProperty({ example: '+233247654321', required: false })
+  @Prop()
+  altPocPhone: string;
 
   @ApiProperty({ example: 'Peter Pan' })
   @Prop()

--- a/api/src/programs/programs.controller.spec.ts
+++ b/api/src/programs/programs.controller.spec.ts
@@ -15,6 +15,7 @@ describe('ProgramsController', () => {
         ProgramsService,
         { provide: getModelToken('Program'), useValue: mockModel },
         { provide: getModelToken('Cohort'), useValue: mockModel },
+        { provide: getModelToken('Company'), useValue: mockModel },
       ],
     }).compile();
 
@@ -46,11 +47,17 @@ describe('ProgramsController', () => {
     expect(result).toEqual(5);
   });
 
-  it('should find one program', async () => {
-    const program = { name: 'Program 1' };
-    jest.spyOn(service, 'findOne').mockResolvedValue(program as any);
+  it('should find one program with stats', async () => {
+    const program = {
+      id: '1',
+      name: 'Program 1',
+      activeCohortsCount: 2,
+      participantsCount: 7,
+    };
+    jest.spyOn(service, 'findOneWithStats').mockResolvedValue(program as any);
     const result = await controller.findOne('1');
     expect(result).toEqual(program);
+    expect(service.findOneWithStats as jest.Mock).toHaveBeenCalledWith('1');
   });
 
   it('should update a program', async () => {

--- a/api/src/programs/programs.controller.ts
+++ b/api/src/programs/programs.controller.ts
@@ -78,7 +78,7 @@ export class ProgramsController {
   })
   @ApiUnauthorizedResponse({ description: 'Unauthorized.' })
   findOne(@Param('id') id: string) {
-    return this.programsService.findOne({ _id: id });
+    return this.programsService.findOneWithStats(id);
   }
 
   @UseGuards(AuthGuard)

--- a/api/src/programs/programs.module.ts
+++ b/api/src/programs/programs.module.ts
@@ -4,12 +4,14 @@ import { ProgramsController } from './programs.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Program, ProgramSchema } from './schemas/program.schema';
 import { Cohort, CohortSchema } from '../cohorts/schemas/cohort.schema';
+import { Company, CompanySchema } from '../companies/schemas/company.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Program.name, schema: ProgramSchema },
       { name: Cohort.name, schema: CohortSchema },
+      { name: Company.name, schema: CompanySchema },
     ]),
   ],
   controllers: [ProgramsController],

--- a/api/src/programs/programs.service.spec.ts
+++ b/api/src/programs/programs.service.spec.ts
@@ -1,11 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProgramsService } from './programs.service';
 import { getModelToken } from '@nestjs/mongoose';
-import { mockModel } from '../common/mocks/model';
 import { ConflictException } from '@nestjs/common';
 
-const programModelMock = { ...mockModel };
-const cohortModelMock = { ...mockModel };
+// Independent mocks per model. (Spreading a shared mock would alias the same
+// jest.fn() across models, so e.g. cohort.countDocuments and
+// company.countDocuments would collide.)
+const makeModelMock = () => ({
+  insertOne: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findById: jest.fn(),
+  updateOne: jest.fn(),
+  countDocuments: jest.fn(),
+  deleteOne: jest.fn(),
+  exec: jest.fn(),
+});
+
+const programModelMock = makeModelMock();
+const cohortModelMock = makeModelMock();
+const companyModelMock = makeModelMock();
 
 describe('ProgramsService', () => {
   let service: ProgramsService;
@@ -17,6 +31,7 @@ describe('ProgramsService', () => {
         ProgramsService,
         { provide: getModelToken('Program'), useValue: programModelMock },
         { provide: getModelToken('Cohort'), useValue: cohortModelMock },
+        { provide: getModelToken('Company'), useValue: companyModelMock },
       ],
     }).compile();
 
@@ -67,6 +82,49 @@ describe('ProgramsService', () => {
       { _id: '1' },
       program,
     );
+  });
+
+  describe('findOneWithStats', () => {
+    it('enriches the program with active-cohort and participant counts', async () => {
+      programModelMock.findOne.mockResolvedValue({
+        name: 'Program 1',
+        toJSON: () => ({ id: 'pid1', name: 'Program 1' }),
+      });
+      cohortModelMock.countDocuments.mockResolvedValue(2); // active cohorts
+      cohortModelMock.find.mockResolvedValue([{ _id: 'c1' }, { _id: 'c2' }]);
+      companyModelMock.countDocuments.mockResolvedValue(7); // participants
+
+      const result = await service.findOneWithStats('pid1');
+
+      expect(result).toEqual({
+        id: 'pid1',
+        name: 'Program 1',
+        activeCohortsCount: 2,
+        participantsCount: 7,
+      });
+      expect(companyModelMock.countDocuments).toHaveBeenCalledWith({
+        cohort: { $in: ['c1', 'c2'] },
+      });
+    });
+
+    it('returns participantsCount 0 when the program has no cohorts', async () => {
+      programModelMock.findOne.mockResolvedValue({
+        toJSON: () => ({ id: 'pid1', name: 'Program 1' }),
+      });
+      cohortModelMock.countDocuments.mockResolvedValue(0);
+      cohortModelMock.find.mockResolvedValue([]);
+
+      const result = await service.findOneWithStats('pid1');
+
+      expect(result).toMatchObject({ activeCohortsCount: 0, participantsCount: 0 });
+      expect(companyModelMock.countDocuments).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the program does not exist', async () => {
+      programModelMock.findOne.mockResolvedValue(null);
+      const result = await service.findOneWithStats('missing');
+      expect(result).toBeNull();
+    });
   });
 
   describe('deleteOne', () => {

--- a/api/src/programs/programs.service.ts
+++ b/api/src/programs/programs.service.ts
@@ -3,12 +3,14 @@ import { InjectModel } from '@nestjs/mongoose';
 import { AnyKeys, Model, QueryFilter, UpdateQuery } from 'mongoose';
 import { Program } from './schemas/program.schema';
 import { Cohort } from '../cohorts/schemas/cohort.schema';
+import { Company } from '../companies/schemas/company.schema';
 
 @Injectable()
 export class ProgramsService {
   constructor(
     @InjectModel(Program.name) private programModel: Model<Program>,
     @InjectModel(Cohort.name) private cohortModel: Model<Cohort>,
+    @InjectModel(Company.name) private companyModel: Model<Company>,
   ) {}
 
   create(doc: AnyKeys<Program>) {
@@ -25,6 +27,46 @@ export class ProgramsService {
 
   findOne(filter: QueryFilter<Program>) {
     return this.programModel.findOne(filter);
+  }
+
+  /**
+   * Fetch a single program by id, enriched with:
+   *  - `activeCohortsCount`: cohorts in the program currently active by date
+   *    (`startDate <= now <= endDate`).
+   *  - `participantsCount`: total companies across all of the program's
+   *    cohorts (participants == companies).
+   *
+   * Returns `null` when not found so the controller mirrors the existing
+   * not-found behaviour. Used by `GET /programs/:id`; list endpoints unchanged.
+   */
+  async findOneWithStats(id: string) {
+    const program = await this.programModel.findOne({ _id: id });
+    if (!program) {
+      return null;
+    }
+
+    const now = new Date();
+    const activeCohortsCount = await this.cohortModel.countDocuments({
+      program: id as any,
+      startDate: { $lte: now },
+      endDate: { $gte: now },
+    });
+
+    const cohorts = await this.cohortModel.find({ program: id as any }, '_id');
+    const cohortIds = cohorts.map((cohort) => cohort._id);
+    const participantsCount =
+      cohortIds.length === 0
+        ? 0
+        : await this.companyModel.countDocuments({
+            cohort: { $in: cohortIds } as any,
+          });
+
+    const base =
+      typeof (program as { toJSON?: () => unknown }).toJSON === 'function'
+        ? (program as { toJSON: () => Record<string, unknown> }).toJSON()
+        : (program as unknown as Record<string, unknown>);
+
+    return { ...base, activeCohortsCount, participantsCount };
   }
 
   updateOne(filter: QueryFilter<Program>, update: UpdateQuery<Program>) {


### PR DESCRIPTION
…ntact fields

- Add findOneWithStats method to CohortsService to fetch cohort with affiliated companies count
- Update cohorts controller to use findOneWithStats for GET /cohorts/:id endpoint
- Add email and phone fields for main and alternative points of contact in CreateCompanyDto
- Add corresponding email and phone properties to Company schema
- Update cohorts and programs controller tests to reflect new service methods and dependencies
- Update programs service to use enriched cohort data with stats
- Enhance test coverage for new findOneWithStats functionality with null handling
- Improve API documentation with additional contact field descriptions