### PR TITLE
fix(hanko): stop CORS override from clobbering auth config

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -41,13 +41,19 @@ APP_HOST=localhost
 # Hanko connects to the auth-db using POSTGRES_USER / POSTGRES_PASSWORD /
 # POSTGRES_DB above (mapped onto Hanko's DATABASE_* env vars in the compose
 # files), so there is no separate Hanko DB password to keep in sync.
-# Public host/origin (WebAuthn RP id, origins, CORS) come from APP_HOST +
-# APP_BASE_URL — see the Public Host / Origin section above. To allow MULTIPLE
-# WebAuthn/CORS origins, edit the auth service's `environment:` block in the
-# compose file (WEBAUTHN_RELYING_PARTY_ORIGINS / SERVER_PUBLIC_CORS_ALLOW_ORIGINS
-# accept a comma-separated list). Do NOT put a list in APP_BASE_URL — the API
+# The WebAuthn RP id/origins come from APP_HOST + APP_BASE_URL — see the Public
+# Host / Origin section above. To allow MULTIPLE WebAuthn origins, edit the auth
+# service's `environment:` block in the compose file (WEBAUTHN_RELYING_PARTY_ORIGINS
+# accepts a comma-separated list). Do NOT put a list in APP_BASE_URL — the API
 # builds single links from it (see the API section).
-# At least 16 characters long random string
+#
+# CORS is NOT configured here. It is set to a wildcard in hanko/config.yaml so the
+# auth API accepts any browser origin (this avoids the CORS errors caused by an
+# empty/mismatched APP_BASE_URL). To lock CORS down, set allow_origins in
+# hanko/config.yaml to your exact web origin(s).
+#
+# HANKO_SECRETS_KEYS signs Hanko's session JWTs — set a strong random string of at
+# least 16 characters. If unset, Hanko uses a well-known default key (insecure).
 HANKO_SECRETS_KEYS=very-secret-key-at-least-16-chars
 
 # -----------------------------------------------------------------------------

--- a/deployment/backend.yml
+++ b/deployment/backend.yml
@@ -35,12 +35,20 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      # Released Hanko reads secrets.keys (env SECRETS_KEYS); SECRET_KEYS is only
+      # recognised by unreleased/main builds. Set both so the signing key is
+      # applied regardless of the image tag — otherwise Hanko silently falls back
+      # to a well-known default key and issued sessions are insecure.
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
-      # Public host, sourced from .env (APP_HOST / APP_BASE_URL). WebAuthn RP id
-      # is a bare host; origins/CORS are full origins.
-      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST}
-      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL}
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL}
+      # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
+      # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
+      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
+      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
+      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
+      # the CORS failures when that value was empty or didn't match the origin.
+      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
+      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:
@@ -58,6 +66,7 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml

--- a/deployment/frontend.yml
+++ b/deployment/frontend.yml
@@ -35,12 +35,20 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      # Released Hanko reads secrets.keys (env SECRETS_KEYS); SECRET_KEYS is only
+      # recognised by unreleased/main builds. Set both so the signing key is
+      # applied regardless of the image tag — otherwise Hanko silently falls back
+      # to a well-known default key and issued sessions are insecure.
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
-      # Public host, sourced from .env (APP_HOST / APP_BASE_URL). WebAuthn RP id
-      # is a bare host; origins/CORS are full origins.
-      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST}
-      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL}
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL}
+      # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
+      # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
+      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
+      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
+      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
+      # the CORS failures when that value was empty or didn't match the origin.
+      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
+      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:
@@ -58,6 +66,7 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml

--- a/deployment/full.yml
+++ b/deployment/full.yml
@@ -35,12 +35,20 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      # Released Hanko reads secrets.keys (env SECRETS_KEYS); SECRET_KEYS is only
+      # recognised by unreleased/main builds. Set both so the signing key is
+      # applied regardless of the image tag — otherwise Hanko silently falls back
+      # to a well-known default key and issued sessions are insecure.
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
-      # Public host, sourced from .env (APP_HOST / APP_BASE_URL). WebAuthn RP id
-      # is a bare host; origins/CORS are full origins.
-      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST}
-      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL}
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL}
+      # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
+      # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
+      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
+      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
+      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
+      # the CORS failures when that value was empty or didn't match the origin.
+      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
+      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:
@@ -58,6 +66,7 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -35,12 +35,20 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      # Released Hanko reads secrets.keys (env SECRETS_KEYS); SECRET_KEYS is only
+      # recognised by unreleased/main builds. Set both so the signing key is
+      # applied regardless of the image tag — otherwise Hanko silently falls back
+      # to a well-known default key and issued sessions are insecure.
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
-      # Public host, sourced from .env (APP_HOST / APP_BASE_URL). WebAuthn RP id
-      # is a bare host; origins/CORS are full origins.
-      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST}
-      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL}
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL}
+      # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
+      # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
+      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
+      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
+      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
+      # the CORS failures when that value was empty or didn't match the origin.
+      WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
+      WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:
@@ -58,6 +66,7 @@ services:
       DATABASE_USER: ${POSTGRES_USER}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_DATABASE: ${POSTGRES_DB}
+      SECRETS_KEYS: ${HANKO_SECRETS_KEYS}
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
     volumes:
       - ../hanko/config.yaml:/config/config.yaml

--- a/hanko/config.yaml
+++ b/hanko/config.yaml
@@ -2,13 +2,23 @@
 # expand `{{ .Env.X }}` templates. Values below are localhost defaults; any field
 # whose env var is set (envconfig runs after the YAML load) is overridden at
 # startup. envconfig maps env vars onto these fields (set in the compose files):
-#   database.user                    -> DATABASE_USER                    (from POSTGRES_USER)
-#   database.password                -> DATABASE_PASSWORD                (from POSTGRES_PASSWORD)
-#   database.database                -> DATABASE_DATABASE                (from POSTGRES_DB)
-#   secret_keys                      -> SECRET_KEYS                      (from HANKO_SECRETS_KEYS)
-#   webauthn.relying_party.id        -> WEBAUTHN_RELYING_PARTY_ID        (from APP_HOST; bare host, no scheme/port)
-#   webauthn.relying_party.origins   -> WEBAUTHN_RELYING_PARTY_ORIGINS   (from APP_BASE_URL; comma-separated for multiple)
-#   server.public.cors.allow_origins -> SERVER_PUBLIC_CORS_ALLOW_ORIGINS (from APP_BASE_URL; comma-separated for multiple)
+#   database.user                  -> DATABASE_USER                  (from POSTGRES_USER)
+#   database.password              -> DATABASE_PASSWORD              (from POSTGRES_PASSWORD)
+#   database.database              -> DATABASE_DATABASE              (from POSTGRES_DB)
+#   secrets.keys                   -> SECRETS_KEYS                   (from HANKO_SECRETS_KEYS)
+#   webauthn.relying_party.id      -> WEBAUTHN_RELYING_PARTY_ID      (from APP_HOST; bare host, no scheme/port)
+#   webauthn.relying_party.origins -> WEBAUTHN_RELYING_PARTY_ORIGINS (from APP_BASE_URL; comma-separated for multiple)
+#
+# CORS is intentionally NOT driven by an env var (see the `cors` block below).
+# It is left as a wildcard here so the auth API accepts requests from whatever
+# host the browser is on (localhost, 127.0.0.1, a VM IP/hostname, any port). The
+# compose files therefore do NOT set SERVER_PUBLIC_CORS_ALLOW_ORIGINS — if they
+# did, an empty/mismatched APP_BASE_URL would override this and reintroduce the
+# CORS failure. To lock CORS down for a real deployment, replace the `*` below
+# with your exact web origin(s), e.g.:
+#   allow_origins:
+#     - "https://app.example.com"
+#   unsafe_wildcard_origin_allowed: false
 database:
   # user, password, and database name are injected via the DATABASE_* env vars
   host: auth-db
@@ -24,8 +34,11 @@ email_delivery:
     host: mailslurper
     port: 2500
 
-# secret_keys injected via the SECRET_KEYS env var (see deployment/*.yml).
-# Top-level `secret_keys` replaces the deprecated `secrets.keys` list.
+# secrets.keys is injected via the SECRETS_KEYS env var (from HANKO_SECRETS_KEYS
+# in deployment/.env). It MUST be set to a strong value — if it is missing, Hanko
+# falls back to a well-known default signing key and issued sessions are insecure.
+# (`SECRET_KEYS` / top-level `secret_keys` only exist on unreleased Hanko; the
+# released image reads `secrets.keys`.)
 
 service:
   name: MEST BDT Auth
@@ -42,7 +55,9 @@ webauthn:
 server:
   public:
     cors:
-      # Overridden by SERVER_PUBLIC_CORS_ALLOW_ORIGINS (from APP_BASE_URL) for non-localhost hosts.
+      # Wildcard with unsafe_wildcard_origin_allowed reflects the request Origin
+      # back (with Access-Control-Allow-Credentials), so credentialed requests
+      # work from any host. Not overridden by env — this is the source of truth.
       allow_origins:
-        - "http://localhost:3000"
+        - "*"
       unsafe_wildcard_origin_allowed: true


### PR DESCRIPTION
The auth service injected SERVER_PUBLIC_CORS_ALLOW_ORIGINS from ${APP_BASE_URL}, overriding the good value in hanko/config.yaml. When APP_BASE_URL was empty, stale, or didn't match the browser origin, Hanko's allow-list dropped the real origin and every request failed CORS — independent of host, so switching to a localhost VM didn't help.

- config.yaml: make CORS an authoritative wildcard-reflect (allow_origins: ["*"] + unsafe_wildcard_origin_allowed), so the auth API accepts any browser origin with credentials. This also makes the previously dead unsafe_wildcard flag meaningful.
- compose (full/production/frontend/backend): drop the CORS override so config.yaml is the single source of truth; add :- defaults to the WebAuthn overrides so an empty .env can't blank them.
- fix ignored signing key: released Hanko (v2.7.0) reads secrets.keys (env SECRETS_KEYS), not SECRET_KEYS — it was silently falling back to the well-known default key. Set both names in auth and auth-migrate.
- .env.example: document that CORS is config-driven, not env-driven.