### PR TITLE
fix(hanko): drive CORS via static env wildcard to fix blocked requests

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -47,10 +47,12 @@ APP_HOST=localhost
 # accepts a comma-separated list). Do NOT put a list in APP_BASE_URL — the API
 # builds single links from it (see the API section).
 #
-# CORS is NOT configured here. It is set to a wildcard in hanko/config.yaml so the
-# auth API accepts any browser origin (this avoids the CORS errors caused by an
-# empty/mismatched APP_BASE_URL). To lock CORS down, set allow_origins in
-# hanko/config.yaml to your exact web origin(s).
+# CORS is set to a static wildcard in the auth service's `environment:` block in
+# the compose files (SERVER_PUBLIC_CORS_ALLOW_ORIGINS / _UNSAFE_WILDCARD_ORIGIN_ALLOWED),
+# so the auth API accepts any browser origin regardless of APP_HOST/APP_BASE_URL.
+# It is intentionally NOT derived from APP_BASE_URL — an empty/mismatched value
+# there was the original cause of the CORS errors. To lock CORS down, set those
+# two env vars (and hanko/config.yaml) to your exact web origin(s).
 #
 # HANKO_SECRETS_KEYS signs Hanko's session JWTs — set a strong random string of at
 # least 16 characters. If unset, Hanko uses a well-known default key (insecure).

--- a/deployment/backend.yml
+++ b/deployment/backend.yml
@@ -43,12 +43,17 @@ services:
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
       # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
       # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
-      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
-      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
-      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
-      # the CORS failures when that value was empty or didn't match the origin.
+      # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
+      # env (not only config.yaml) so CORS works even if the config.yaml volume
+      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
+      # together — "*" without the unsafe flag fails Hanko's startup validation.
+      # For production, replace "*" with your exact web origin and set the flag to
+      # "false".
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/frontend.yml
+++ b/deployment/frontend.yml
@@ -43,12 +43,17 @@ services:
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
       # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
       # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
-      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
-      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
-      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
-      # the CORS failures when that value was empty or didn't match the origin.
+      # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
+      # env (not only config.yaml) so CORS works even if the config.yaml volume
+      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
+      # together — "*" without the unsafe flag fails Hanko's startup validation.
+      # For production, replace "*" with your exact web origin and set the flag to
+      # "false".
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/full.yml
+++ b/deployment/full.yml
@@ -43,12 +43,17 @@ services:
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
       # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
       # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
-      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
-      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
-      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
-      # the CORS failures when that value was empty or didn't match the origin.
+      # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
+      # env (not only config.yaml) so CORS works even if the config.yaml volume
+      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
+      # together — "*" without the unsafe flag fails Hanko's startup validation.
+      # For production, replace "*" with your exact web origin and set the flag to
+      # "false".
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -43,12 +43,17 @@ services:
       SECRET_KEYS: ${HANKO_SECRETS_KEYS}
       # Public host for WebAuthn: RP id is a bare host, origins are full URLs. The
       # `:-` defaults stop a missing/empty APP_HOST/APP_BASE_URL from clobbering
-      # the localhost defaults in hanko/config.yaml. CORS is deliberately NOT set
-      # here — it is owned by hanko/config.yaml (wildcard) so requests from any
-      # browser origin are accepted. Injecting it from APP_BASE_URL is what caused
-      # the CORS failures when that value was empty or didn't match the origin.
+      # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
+      # env (not only config.yaml) so CORS works even if the config.yaml volume
+      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
+      # together — "*" without the unsafe flag fails Hanko's startup validation.
+      # For production, replace "*" with your exact web origin and set the flag to
+      # "false".
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/hanko/config.yaml
+++ b/hanko/config.yaml
@@ -9,13 +9,15 @@
 #   webauthn.relying_party.id      -> WEBAUTHN_RELYING_PARTY_ID      (from APP_HOST; bare host, no scheme/port)
 #   webauthn.relying_party.origins -> WEBAUTHN_RELYING_PARTY_ORIGINS (from APP_BASE_URL; comma-separated for multiple)
 #
-# CORS is intentionally NOT driven by an env var (see the `cors` block below).
-# It is left as a wildcard here so the auth API accepts requests from whatever
-# host the browser is on (localhost, 127.0.0.1, a VM IP/hostname, any port). The
-# compose files therefore do NOT set SERVER_PUBLIC_CORS_ALLOW_ORIGINS — if they
-# did, an empty/mismatched APP_BASE_URL would override this and reintroduce the
-# CORS failure. To lock CORS down for a real deployment, replace the `*` below
-# with your exact web origin(s), e.g.:
+# CORS is ALSO set via env in the compose files, which is the authoritative
+# channel (envconfig applies env vars after this file loads, and works even if
+# this file fails to mount and Hanko falls back to its defaults):
+#   server.public.cors.allow_origins                 -> SERVER_PUBLIC_CORS_ALLOW_ORIGINS                 (static "*")
+#   server.public.cors.unsafe_wildcard_origin_allowed -> SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED (static "true")
+# The wildcard below is a fallback with the same effect. Both the origin list and
+# the unsafe flag must agree — a "*" origin without the flag fails startup
+# validation. To lock CORS down for a real deployment, set both the env vars and
+# the block below to your exact web origin(s), e.g.:
 #   allow_origins:
 #     - "https://app.example.com"
 #   unsafe_wildcard_origin_allowed: false


### PR DESCRIPTION
Hanko was returning no Access-Control-Allow-Origin header, blocking the web app at :3000 from calling the auth API at :8000. Relying on hanko/config.yaml alone failed when the config volume didn't mount: Hanko fell back to its defaults (allow_origins: localhost:8888), which exclude the app origin.

Set CORS through the auth service environment, which envconfig always applies regardless of whether config.yaml mounts, using a static "*" that APP_BASE_URL can't clobber:

- compose (full/production/frontend/backend): add SERVER_PUBLIC_CORS_ALLOW_ORIGINS="*" and SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED="true" to auth. Both are required together — "*" without the unsafe flag fails Hanko's startup validation. Hanko then reflects the request origin with AllowCredentials.
- config.yaml keeps the "*" fallback; update comments to note env is the authoritative channel.
- .env.example: document that CORS is a static wildcard, not derived from APP_BASE_URL.

Restrict "*" to the exact web origin for production.