### PR TITLE
fix(hanko): use explicit CORS origins to fix blocked credentialed req…

### DIFF
--- a/deployment/backend.yml
+++ b/deployment/backend.yml
@@ -46,14 +46,12 @@ services:
       # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
-      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
-      # env (not only config.yaml) so CORS works even if the config.yaml volume
-      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
-      # together — "*" without the unsafe flag fails Hanko's startup validation.
-      # For production, replace "*" with your exact web origin and set the flag to
-      # "false".
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
-      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
+      # CORS: Set CORS specifically for Web UI origin to allow credentialed cookies/headers.
+      # Support both split-words and non-split-words formats (envconfig mapping styles) for v3.
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_ALLOWORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "false"
+      SERVER_PUBLIC_CORS_UNSAFEWILDCARDORIGINALLOWED: "false"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/frontend.yml
+++ b/deployment/frontend.yml
@@ -46,14 +46,12 @@ services:
       # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
-      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
-      # env (not only config.yaml) so CORS works even if the config.yaml volume
-      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
-      # together — "*" without the unsafe flag fails Hanko's startup validation.
-      # For production, replace "*" with your exact web origin and set the flag to
-      # "false".
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
-      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
+      # CORS: Set CORS specifically for Web UI origin to allow credentialed cookies/headers.
+      # Support both split-words and non-split-words formats (envconfig mapping styles) for v3.
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_ALLOWORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "false"
+      SERVER_PUBLIC_CORS_UNSAFEWILDCARDORIGINALLOWED: "false"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/full.yml
+++ b/deployment/full.yml
@@ -46,14 +46,12 @@ services:
       # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
-      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
-      # env (not only config.yaml) so CORS works even if the config.yaml volume
-      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
-      # together — "*" without the unsafe flag fails Hanko's startup validation.
-      # For production, replace "*" with your exact web origin and set the flag to
-      # "false".
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
-      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
+      # CORS: Set CORS specifically for Web UI origin to allow credentialed cookies/headers.
+      # Support both split-words and non-split-words formats (envconfig mapping styles) for v3.
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_ALLOWORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "false"
+      SERVER_PUBLIC_CORS_UNSAFEWILDCARDORIGINALLOWED: "false"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -46,14 +46,12 @@ services:
       # the localhost defaults in hanko/config.yaml.
       WEBAUTHN_RELYING_PARTY_ID: ${APP_HOST:-localhost}
       WEBAUTHN_RELYING_PARTY_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
-      # CORS: static wildcard so the auth API reflects ANY browser origin. Set via
-      # env (not only config.yaml) so CORS works even if the config.yaml volume
-      # fails to mount and Hanko falls back to its defaults. Both vars are REQUIRED
-      # together — "*" without the unsafe flag fails Hanko's startup validation.
-      # For production, replace "*" with your exact web origin and set the flag to
-      # "false".
-      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: "*"
-      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "true"
+      # CORS: Set CORS specifically for Web UI origin to allow credentialed cookies/headers.
+      # Support both split-words and non-split-words formats (envconfig mapping styles) for v3.
+      SERVER_PUBLIC_CORS_ALLOW_ORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_ALLOWORIGINS: ${APP_BASE_URL:-http://localhost:3000}
+      SERVER_PUBLIC_CORS_UNSAFE_WILDCARD_ORIGIN_ALLOWED: "false"
+      SERVER_PUBLIC_CORS_UNSAFEWILDCARDORIGINALLOWED: "false"
     volumes:
       - ../hanko/config.yaml:/config/config.yaml
     depends_on:

--- a/hanko/config.yaml
+++ b/hanko/config.yaml
@@ -57,9 +57,8 @@ webauthn:
 server:
   public:
     cors:
-      # Wildcard with unsafe_wildcard_origin_allowed reflects the request Origin
-      # back (with Access-Control-Allow-Credentials), so credentialed requests
-      # work from any host. Not overridden by env — this is the source of truth.
+      # Explicitly allow the local web application origin to ensure browsers
+      # do not block credentialed CORS requests.
       allow_origins:
-        - "*"
-      unsafe_wildcard_origin_allowed: true
+        - "http://localhost:3000"
+      unsafe_wildcard_origin_allowed: false


### PR DESCRIPTION
…uests on localhost (#3)

Hanko was returning wildcard CORS origins when SERVER_PUBLIC_CORS_ALLOW_ORIGINS="*" was parsed, causing browsers to block credentialed requests (cookies/auth headers) on localhost.
- Configure hanko/config.yaml to explicitly list http://localhost:3000 as allowed origin.
- Set both split-word and non-split-word styles for Go envconfig environment variables in compose files (full.yml, production.yml, backend.yml, frontend.yml) to ensure they are parsed correctly.